### PR TITLE
Pausing Animation

### DIFF
--- a/frontend/src/scripts/Animation/initialization.js
+++ b/frontend/src/scripts/Animation/initialization.js
@@ -25,8 +25,8 @@ function initializeCanvaArray(size,canvas,twoRows=false){
 * for each element in the input array
 * @param array: the array to draw on the canvas element
 */
-function drawArray(array,canvas,offset) {
-  var raf;
+function drawArray(array,canvas,offset,callback=()=>{},raf=[]) {
+  // var raf;
   var count = offset;
 
   if (canvas.getContext) {
@@ -51,7 +51,9 @@ function drawArray(array,canvas,offset) {
       }
 
       if (array[0].numFrames > 0)
-        raf = window.requestAnimationFrame(draw);
+        raf[0] = window.requestAnimationFrame(draw);
+      else
+        callback();
     }
   }
 }

--- a/frontend/src/scripts/Sorting/bubbleSort.js
+++ b/frontend/src/scripts/Sorting/bubbleSort.js
@@ -1,10 +1,9 @@
 import * as Animation from "../Animation/movement"
 import * as Paint from "../Animation/coloring";
-import { drawArray } from '../Animation/initialization';
 import { swap } from './sortHelper';
 import { color } from '../../styles/GlobalStyles';
 
-function bubbleSort(canvas,array,velocity) {
+function bubbleSort(array,velocity) {
     // shade all elements to start
     Paint.shade(array, array);
 
@@ -40,7 +39,6 @@ function bubbleSort(canvas,array,velocity) {
 
     // sorted, restore color and start animation
     Paint.restoreColor(array, array);
-    drawArray(array, canvas, 1);
 }
 
 export default bubbleSort;

--- a/frontend/src/scripts/Sorting/heapSort.js
+++ b/frontend/src/scripts/Sorting/heapSort.js
@@ -1,15 +1,14 @@
 import * as Animation from "../Animation/movement"
 import * as Paint from "../Animation/coloring";
-import { drawArray } from '../Animation/initialization';
 import { swap } from './sortHelper';
 import { color } from '../../styles/GlobalStyles';
 
-var canvas, array, velocity, currentSize;
+var array, velocity, currentSize;
 const leftChild = (pos) => (pos+1)*2 - 1;
 const parent = (pos) => Math.floor( (pos+1)/2 - 1 );
 
 function heapSort(...args) {
-    [canvas, array, velocity] = args;
+    [array, velocity] = args;
     currentSize = array.length;
 
     buildHeap();
@@ -17,8 +16,6 @@ function heapSort(...args) {
         deleteMax();
     }
     Paint.restoreColor(array,array);
-
-    drawArray(array, canvas, 1);
 }
 
 /*

--- a/frontend/src/scripts/Sorting/insertionSort.js
+++ b/frontend/src/scripts/Sorting/insertionSort.js
@@ -1,10 +1,9 @@
 import * as Animation from "../Animation/movement"
 import * as Paint from "../Animation/coloring";
-import { drawArray } from '../Animation/initialization';
 import { swap } from './sortHelper';
 import { color } from '../../styles/GlobalStyles';
 
-function insertionSort(canvas,array,velocity) {
+function insertionSort(array,velocity) {
     // shade all elements first
     Paint.shade(array,array);
     // calls the private helper method
@@ -12,8 +11,6 @@ function insertionSort(canvas,array,velocity) {
 
     // insertion done, restore the color of all elements in array
     Paint.restoreColor(array,array);
-
-    drawArray(array,canvas,1);
 }
 
 function insertionSortHelper(array,begin,end,velocity,use3Color=false){

--- a/frontend/src/scripts/Sorting/mergeSort.js
+++ b/frontend/src/scripts/Sorting/mergeSort.js
@@ -1,6 +1,6 @@
 import * as Animation from "../Animation/movement";
 import * as Paint from "../Animation/coloring";
-import { drawArray, getWidthSpace, calculateX, calculateY } from '../Animation/initialization';
+import { getWidthSpace, calculateX, calculateY } from '../Animation/initialization';
 import { color } from '../../styles/GlobalStyles';
 
 var canvasHeight, canvasWidth, VELOCITY, WIDTH, SPACE;
@@ -15,7 +15,7 @@ function calcX(index) {
     return calculateX(index, WIDTH, SPACE);
 }
 
-function mergeSort(canvas, array, velocity) {
+function mergeSort(array, velocity, canvas) {
     canvasHeight = canvas.height; canvasWidth = canvas.width;
     [WIDTH, SPACE] = getWidthSpace(canvasWidth, array.length);
     VELOCITY = velocity;
@@ -23,7 +23,6 @@ function mergeSort(canvas, array, velocity) {
     var tmpArray = new Array(array.length).fill();
     // initially all elements are highlighted
     mergeSortHelper(array,tmpArray,0,array.length-1);
-    drawArray(array,canvas,1);
 }
 
 function mergeSortHelper(array, tmpArray, begin, end) {

--- a/frontend/src/scripts/Sorting/quickSort.js
+++ b/frontend/src/scripts/Sorting/quickSort.js
@@ -1,17 +1,14 @@
 import * as Animation from "../Animation/movement"
 import * as Paint from "../Animation/coloring";
-import { drawArray } from '../Animation/initialization';
 import { color } from '../../styles/GlobalStyles';
 import { swap } from './sortHelper';
 import { insertionSortHelper as insertionSort} from './insertionSort';
 
-function quickSort(canvas,array,velocity){
+function quickSort(array,velocity){
     // calls the helper method
     quickSortHelper(0,array.length-1);
     // all elements sorted, restore color
     Paint.restoreColor(array, array);
-
-    drawArray(array,canvas,1);
     
     // helper method that sorts the input array
     // and draws every step on the canvas

--- a/frontend/src/scripts/Sorting/shellSort.js
+++ b/frontend/src/scripts/Sorting/shellSort.js
@@ -1,10 +1,9 @@
 import * as Animation from "../Animation/movement"
 import * as Paint from "../Animation/coloring";
-import { drawArray } from '../Animation/initialization';
 import { swap } from './sortHelper';
 import { color } from '../../styles/GlobalStyles';
 
-function shellSort(canvas,array,velocity) {
+function shellSort(array,velocity) {
     Paint.shade(array,array);
 
     var hibbardIncrement = getHibbardIncrement(array.length);
@@ -36,10 +35,7 @@ function shellSort(canvas,array,velocity) {
         }
     }
 
-    console.log(array.map( (el) => el.value) );
-
     Paint.restoreColor(array,array); // sorted, restore color
-    drawArray(array, canvas, 1); // start animation
 }
 
 function getHibbardIncrement(length) {


### PR DESCRIPTION
Bugs fixed:

- When an animation is completed, the start animation button now becomes "Move". This is achieved by passing a callback - from the component instance that changes the display text of the button instance - to the draw() function that calls requestAnimationFrame.

New Feature

- Animation can now be paused by hitting the pause button. This is achieved by allowing draw() to constantly update the raf attribute of the component instance when invoking requestAnimationFrame. When the pause button is clicked, we pause the animation by calling windwos.cancelAnimationFrame(raf[0]). Note that a raf array is passed into draw() to leverage the fact that arrays are passed by reference. This allows draw to dynamically update raf by modifying raf[0] each time requestAnimation is called.

Code Structures

- drawArray() is decoupled from the sort routine. For all algorithms but mergeSort, we no longer need to pass in canvas. However, for consistency, canvas is still being passed in when calling sort, but as the last parameter. Only mergeSort made use of this last parameter. For other routines, this parameter is simply ignored.